### PR TITLE
🐳 add Dockerfile and configuration by environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The docker-compose.yml features a configuration for linux/amd64 and linux/armv7 
 
 Configuration of the docker containers can be done by setting environment variable, such that a config file is not required anymore.
 All configuration parameters of the config.yml can be reused with the prefix `HUEKIT_` in order to be set via the environment.
+An example configuration can be found in the docker-compose.yml.
 The following environment variables are available:
 
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,27 @@
 In order to build the binary, just run `make build`. The binary will be placed in the `./bin` directory.
 
 
+## 🐳 Docker
+
+This project features a Dockerfile, docker-compose file and the way to read the configuration from the environment.
+The Dockerfile can be found in `build/package/docker/huekit` and the docker-compose.yml in `deployments/docker`.
+For building an image for different OS and CPU architextures, the Dockerfile features build arguments, that allow cross compiling the binary.
+The docker-compose.yml features a configuration for linux/amd64 and linux/armv7 (compatible with raspberry pi).
+
+
+Configuration of the docker containers can be done by setting environment variable, such that a config file is not required anymore.
+All configuration parameters of the config.yml can be reused with the prefix `HUEKIT_` in order to be set via the environment.
+The following environment variables are available:
+
+
+| Name | Description |
+|------|-------------|
+| `HUEKIT_LOG_LEVEL` | Set the verbosity of the service. |
+| `HUEKIT_LOG_FORMAT` | Decide, if you want `json` or `text` logs |
+| `HUEKIT_BRIDGE_ADDRESS` | IP address of the hue bridge  |
+| `HUEKIT_HOMEKIT_PIN` | Pin, that must be entered in homekit for pairing with huekit |
+
+
 ## 🤝 Contributing
 
 If you are missing features or find some annoying bugs please feel free to submit an issue or a bugfix within a pull request :)

--- a/build/package/docker/huekit/Dockerfile
+++ b/build/package/docker/huekit/Dockerfile
@@ -1,0 +1,38 @@
+# STEP 1 - Build the binary
+
+# use the golang image as build image
+FROM golang
+
+# build arguments in order to reuse it for arm containers
+ARG GOOS=linux
+ARG GOARCH=amd64
+ARG GOARM
+
+# activate go modules
+ENV GO111MODULE on
+
+# copy the local package files to the container's workspace.
+COPY . /go/src/github.com/dj95/huekit
+
+# set the working directory to build the application
+WORKDIR /go/src/github.com/dj95/huekit
+
+# compile the program
+RUN CGO_ENABLED=0 GOOS="${GOOS}" GOARCH="${GOARCH}" go build \
+    -ldflags="-s -w" \
+    -a \
+    -installsuffix cgo \
+    -o /go/bin/huekit \
+    /go/src/github.com/dj95/huekit/cmd/huekit/main.go
+
+
+# STEP 2 - Build a minimal container
+
+# start from scratch
+FROM scratch
+
+# copy the static executable
+COPY --from=0 /go/bin/huekit /huekit
+
+# define the entrypoint
+ENTRYPOINT ["/huekit"]

--- a/cmd/huekit/main.go
+++ b/cmd/huekit/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	badger "github.com/dgraph-io/badger/v2"
+	"github.com/dgraph-io/badger/v2/options"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -30,10 +31,18 @@ func init() {
 		viper.SetConfigFile(viper.GetString("config"))
 	}
 
+	// set the env prefix to HUEKIT_ for configuration via
+	// environment variables
+	viper.SetEnvPrefix("HUEKIT")
+
 	// read the config file
 	if err := viper.ReadInConfig(); err != nil {
 		log.Warnf("Cannot read config file: %s", err.Error())
 	}
+
+	// read the configuration from the environment and override
+	// the given values in the config file with it
+	viper.AutomaticEnv()
 
 	// set the default log level and mode
 	log.SetLevel(log.InfoLevel)
@@ -74,7 +83,8 @@ func main() {
 	db, err := badger.Open(
 		badger.
 			DefaultOptions("./huekit_data").
-			WithLogger(log.StandardLogger()),
+			WithLogger(log.StandardLogger()).
+			WithValueLogLoadingMode(options.FileIO),
 	)
 
 	// error handling

--- a/cmd/huekit/main.go
+++ b/cmd/huekit/main.go
@@ -37,7 +37,7 @@ func init() {
 
 	// read the config file
 	if err := viper.ReadInConfig(); err != nil {
-		log.Warnf("Cannot read config file: %s", err.Error())
+		log.Warnf("Cannot read a config file. Trying to fetch config from env.")
 	}
 
 	// read the configuration from the environment and override
@@ -79,6 +79,10 @@ func init() {
 }
 
 func main() {
+	if viper.GetString("bridge_address") == "" || viper.GetString("homekit_pin") == "" {
+		log.Fatal("Invalid configuration! Either 'bridge_address' or 'homekit_pin' are missing!")
+	}
+
 	// open the database
 	db, err := badger.Open(
 		badger.

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -6,6 +6,11 @@ services:
       dockerfile: build/package/docker/huekit/Dockerfile
     image: 'github.com/dj95/huekit:${VERSION:-dev}'
     network_mode: 'host'
+    environment:
+      HUEKIT_LOG_LEVEL: 'info'
+      HUEKIT_LOG_FORMAT: 'json'
+      HUEKIT_BRIDGE_ADDRESS: '127.0.0.1'
+      HUEKIT_HOMEKIT_PIN: '00102003'
 
   bridge_rpi:
     build:

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.5'
+services:
+  bridge:
+    build:
+      context: '../..'
+      dockerfile: build/package/docker/huekit/Dockerfile
+    image: 'github.com/dj95/huekit:${VERSION:-dev}'
+    network_mode: 'host'
+
+  bridge_rpi:
+    build:
+      context: '../..'
+      dockerfile: build/package/docker/huekit/Dockerfile
+      args:
+        GOARCH: 'arm'
+        GOARM: '7'
+    image: 'github.com/dj95/huekit:armv7-${VERSION:-dev}'
+    network_mode: 'host'


### PR DESCRIPTION
For a simplified usage of huekit, a docker image should be available. It should be a flexible solution, which also allows the user to deploy the docker image on a raspberry pi. Therefore this pull request introduces a Dockerfile + docker-compose.yml with build-args in order to build cross platform images.

In order to configure the docker container more easily, the configuration via environment variables was implemented. Every option in the config file can now be used as an environment variable with the prefix `HUEKIT_`.