### PR TITLE
Allow port configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following environment variables are available:
 | `HUEKIT_LOG_FORMAT` | Decide, if you want `json` or `text` logs |
 | `HUEKIT_BRIDGE_ADDRESS` | IP address of the hue bridge  |
 | `HUEKIT_HOMEKIT_PIN` | Pin, that must be entered in homekit for pairing with huekit |
+| `HUEKIT_HOMEKIT_PORT` | Port that huekit will listen on for homekit  |
 
 
 ## 🤝 Contributing

--- a/cmd/huekit/main.go
+++ b/cmd/huekit/main.go
@@ -135,6 +135,7 @@ func main() {
 
 	homekit.StartBridge(
 		viper.GetString("homekit_pin"),
+		viper.GetString("homekit_port"),
 		lights,
 		bridge,
 	)

--- a/configs/config.yml.dist
+++ b/configs/config.yml.dist
@@ -28,3 +28,9 @@ bridge_address: ""
 # field. Very simple pins(such as 12345678) are blocked. The pin
 # MUST be a 8 digits long.
 homekit_pin: "00102003"
+
+# listening port for homekit
+#
+# listening port for homekit connection. If none specified then a
+# random port will be used.
+homekit_port: ""

--- a/pkg/homekit/homekit.go
+++ b/pkg/homekit/homekit.go
@@ -10,7 +10,7 @@ import (
 )
 
 // StartBridge Create a bridge, required accessories and start the bridge
-func StartBridge(pin string, lights []*hue.Light, bridge hue.Bridger) {
+func StartBridge(pin string, port string, lights []*hue.Light, bridge hue.Bridger) {
 	// create the bridge accessory
 	bridgeAccessory := accessory.NewBridge(accessory.Info{
 		ID:   1,
@@ -24,7 +24,7 @@ func StartBridge(pin string, lights []*hue.Light, bridge hue.Bridger) {
 	// create the ip transport, that publishes homekit functionality
 	// and acts as the bridge
 	t, err := hc.NewIPTransport(
-		hc.Config{Pin: pin},
+		hc.Config{Port: port, Pin: pin},
 		bridgeAccessory.Accessory,
 		accessories[:]...,
 	)


### PR DESCRIPTION
I run a firewall on the machine I'm running HueKit on and so needed to configure the specific listening port. This change adds a new config (`homekit_port`) that will be used. In addition to the specified TCP `5353` needs to be open for both UDP and TCP. If no port is specified a random port will be used as today.